### PR TITLE
randomize tile variety on level

### DIFF
--- a/src/Board.lua
+++ b/src/Board.lua
@@ -13,9 +13,12 @@
 
 Board = Class{}
 
-function Board:init(x, y)
+function Board:init(x, y, level)
     self.x = x
     self.y = y
+
+    -- Level to determine the variety of tiles generated
+    self.level = level
     self.matches = {}
 
     self:initializeTiles()
@@ -31,8 +34,10 @@ function Board:initializeTiles()
 
         for tileX = 1, 8 do
             
+            -- Randomize the tile variety based on the level
+            local tileVariety = math.random(math.min(6, math.ceil(self.level/2)))
             -- create a new tile at X,Y with a random color and variety
-            table.insert(self.tiles[tileY], Tile(tileX, tileY, math.random(18), math.random(6)))
+            table.insert(self.tiles[tileY], Tile(tileX, tileY, math.random(18), tileVariety))
         end
     end
 

--- a/src/states/BeginGameState.lua
+++ b/src/states/BeginGameState.lua
@@ -19,9 +19,6 @@ function BeginGameState:init()
     -- start our transition alpha at full, so we fade in
     self.transitionAlpha = 255
 
-    -- spawn a board and place it toward the right
-    self.board = Board(VIRTUAL_WIDTH - 272, 16)
-
     -- start our level # label off-screen
     self.levelLabelY = -64
 end
@@ -30,6 +27,9 @@ function BeginGameState:enter(def)
     
     -- grab level # from the def we're passed
     self.level = def.level
+
+    -- spawn a board and place it toward the right
+    self.board = Board(VIRTUAL_WIDTH - 272, 16, self.level)
 
     --
     -- animate our white screen fade-in, then animate a drop-down with

--- a/src/states/PlayState.lua
+++ b/src/states/PlayState.lua
@@ -196,8 +196,12 @@ function PlayState:calculateMatches()
         -- add score for each match
         -- Update timer based on number of matches
         for k, match in pairs(matches) do
-            self.score = self.score + #match * 50
             self.timer = self.timer + #match
+            
+            -- Calculate score based on the tile variety
+            for j, tile in pairs(match) do
+                self.score = self.score + (tile.variety * 100)
+            end
         end
 
         -- remove any tiles that matched from the board, making empty spaces


### PR DESCRIPTION
- Tile variety is randomized based on the level. The higher the level, the more variety chances will be there
- Use variety to calculate score after the matches. Don't use the matches length